### PR TITLE
非シークレット投稿時に upstreamURL へのリンクが切れていた問題を修正

### DIFF
--- a/src/server/views/post/follower.ts
+++ b/src/server/views/post/follower.ts
@@ -3,7 +3,7 @@ import { getPostEmbedBase, PostProps } from "src/server/views/post/index";
 
 type AdditionalData = Pick<PostProps, "userId" | "favoriteCount" | "shareCount" | "upstreamURL">;
 function getAdditionalDataView({ userId, favoriteCount, shareCount, upstreamURL }: AdditionalData): string {
-  const upstreamURLView = upstreamURL === undefined ? "🤫 シークレット" : "🔎 [here](${upstreamURL})";
+  const upstreamURLView = upstreamURL === undefined ? "🤫 シークレット" : `🔎 [here](${upstreamURL})`;
   return `❤ \`${favoriteCount}\` 🔁 \`${shareCount}\` ${upstreamURLView} 👤 ${getUserReference(userId)}`;
 }
 


### PR DESCRIPTION
#15 の解決です．

#14 のマージ後に，非シークレット投稿での `upstreamURL` へのリンクが
無効になるリグレッションが発生しました．この PR ではそれを解決しています．

---

closes #15.
